### PR TITLE
Added default value for $state.previous

### DIFF
--- a/angular-gsapify-router.js
+++ b/angular-gsapify-router.js
@@ -85,6 +85,7 @@
         self.$get = ['$rootScope', '$state', '$document', '$injector', '$timeout', '$q', '$log', 'TweenMax',
             function($rootScope, $state, $document, $injector, $timeout, $q, $log, TweenMax) {
                 $state.history = [];
+                $state.previous = {};
 
                 $rootScope.$on('$stateChangeSuccess', function(event, toState, toParams, fromState, fromParams) {
                     $state.previous = fromState;


### PR DESCRIPTION
This fixes the 'cannot read property data on undefined' issues on the first attempted state change. The root of the issue was the $state.previous didn't have an initial value, so was undefined.