### PR TITLE
Ui router 1.0 Support

### DIFF
--- a/angular-gsapify-router.js
+++ b/angular-gsapify-router.js
@@ -337,17 +337,12 @@
       $state.previous = {};
 
       $transitions.onSuccess({}, function(transition){
-        console.log("transitions ", transition);
-        console.log("--------");
-        console.log(transition.$from(), transition.$to())
-
         $state.previous = transition.$from();
         $state.previousParams = transition.$from().params;
         $state.history.push({
           name: transition.$from().name,
           params: transition.$from().params
         });
-        console.log("state history >", $state.history);
       })
 
     }])
@@ -379,7 +374,6 @@
             name: $state.current.name,
             params: $state.params,
           };
-          console.log("CURRENT STATE KEY >>>", getCurrentStateKey);
 
           return JSON.stringify(currentState);
         };
@@ -408,7 +402,6 @@
 
 
         $rootScope.$on('gsapifyRouter:' + gsapifyRouter.scrollRecallEvent, function (event, element) {
-          console.log("on gasprouter event");
           if (!service.view) {
             return;
           }
@@ -478,13 +471,10 @@
             };
           },
           leave: function (element, done) {
-
-            console.log("leave animaton");
             var state = element.attr('data-state');
 
             if (state !== 'gsapifyRouterBlankState') {
               $rootScope.$broadcast('gsapifyRouter:leaveStart', element);
-              console.log("leaving ", element);
               gsapifyRouter.leave(element).then(function (obj) {
                 $rootScope.$broadcast('gsapifyRouter:leaveSuccess', element, obj);
 

--- a/angular-gsapify-router.js
+++ b/angular-gsapify-router.js
@@ -332,19 +332,24 @@
       $stateProvider.state('gsapifyRouterBlankState', {});
     }])
 
-    .run(['$rootScope', '$state', 'gsapifyRouter', '$timeout', function ($rootScope, $state, gsapifyRouter, $timeout) {
+    .run(['$rootScope', '$state', 'gsapifyRouter', '$timeout', '$transitions', function ($rootScope, $state, gsapifyRouter, $timeout, $transitions) {
       $state.history = [];
       $state.previous = {};
 
-      $rootScope.$on('$stateChangeSuccess', function (event, toState, toParams, fromState, fromParams) {
-        $state.previous = fromState;
-        $state.previousParams = fromParams;
+      $transitions.onSuccess({}, function(transition){
+        console.log("transitions ", transition);
+        console.log("--------");
+        console.log(transition.$from(), transition.$to())
 
+        $state.previous = transition.$from();
+        $state.previousParams = transition.$from().params;
         $state.history.push({
-          name: fromState.name,
-          params: fromParams,
+          name: transition.$from().name,
+          params: transition.$from().params
         });
-      });
+        console.log("state history >", $state.history);
+      })
+
     }])
 
     .directive('gsapifyRouter', ['$state', '$timeout',
@@ -363,8 +368,8 @@
       },
     ])
 
-    .service('scrollRecallService', ['$rootScope', '$window', '$document', '$timeout', '$state', 'gsapifyRouter',
-      function ($rootScope, $window, $document, $timeout, $state, gsapifyRouter) {
+    .service('scrollRecallService', ['$rootScope', '$window', '$document', '$timeout', '$state', 'gsapifyRouter', '$transitions',
+      function ($rootScope, $window, $document, $timeout, $state, gsapifyRouter, $transitions) {
         var service = {
           view: null,
         };
@@ -374,6 +379,7 @@
             name: $state.current.name,
             params: $state.params,
           };
+          console.log("CURRENT STATE KEY >>>", getCurrentStateKey);
 
           return JSON.stringify(currentState);
         };
@@ -381,7 +387,7 @@
         var scrollMap = {};
         var currentStateKey = getCurrentStateKey();
 
-        $rootScope.$on('$stateChangeStart', function () {
+        $transitions.onStart({}, function(transition){
           if (!service.view) {
             return;
           }
@@ -392,7 +398,7 @@
           };
         });
 
-        $rootScope.$on('$stateChangeSuccess', function () {
+        $transitions.onSuccess({}, function(transition){
           if (!service.view) {
             return;
           }
@@ -400,7 +406,9 @@
           currentStateKey = getCurrentStateKey();
         });
 
+
         $rootScope.$on('gsapifyRouter:' + gsapifyRouter.scrollRecallEvent, function (event, element) {
+          console.log("on gasprouter event");
           if (!service.view) {
             return;
           }
@@ -470,11 +478,13 @@
             };
           },
           leave: function (element, done) {
+
+            console.log("leave animaton");
             var state = element.attr('data-state');
 
             if (state !== 'gsapifyRouterBlankState') {
               $rootScope.$broadcast('gsapifyRouter:leaveStart', element);
-
+              console.log("leaving ", element);
               gsapifyRouter.leave(element).then(function (obj) {
                 $rootScope.$broadcast('gsapifyRouter:leaveSuccess', element, obj);
 

--- a/angular-gsapify-router.js
+++ b/angular-gsapify-router.js
@@ -332,7 +332,7 @@
       $stateProvider.state('gsapifyRouterBlankState', {});
     }])
 
-    .run(['$rootScope', '$state', 'gsapifyRouter', '$timeout', '$transitions', function ($rootScope, $state, gsapifyRouter, $timeout, $transitions) {
+    .run(['$state', '$transitions', function ($state, $transitions) {
       $state.history = [];
       $state.previous = {};
 
@@ -363,8 +363,8 @@
       },
     ])
 
-    .service('scrollRecallService', ['$rootScope', '$window', '$document', '$timeout', '$state', 'gsapifyRouter', '$transitions',
-      function ($rootScope, $window, $document, $timeout, $state, gsapifyRouter, $transitions) {
+    .service('scrollRecallService', ['$rootScope', '$window', '$state', 'gsapifyRouter', '$transitions',
+      function ($rootScope, $window, $state, gsapifyRouter, $transitions) {
         var service = {
           view: null,
         };

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-gsapify-router",
-  "version": "0.0.34",
+  "version": "0.1.0",
   "description": "Angular UI-Router animation directive allowing configuration of state transitions using GSAP",
   "main": "angular-gsapify-router.js",
   "ignore": [
@@ -12,7 +12,7 @@
     "angular": ">=1.2.0",
     "angular-animate": ">=1.2.0",
     "gsap": "~1.19.1",
-    "angular-ui-router": "~0.4.2",
+    "angular-ui-router": "~1.0.6",
     "font-awesome": "~4.7.0",
     "mobile-angular-ui": "~1.3.4",
     "overthrow": "~1.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-gsapify-router",
-  "version": "0.0.35",
+  "version": "0.1.0",
   "description": "Angular UI-Router animation directive allowing configuration of state transitions using [GSAP](http://www.greensock.com/gsap-js/)",
   "main": "index.js",
   "repository": {
@@ -16,7 +16,7 @@
     "angular": ">=1.2.0",
     "angular-animate": ">=1.2.0",
     "gsap": "~1.18.0",
-    "angular-ui-router": "~0.2.15"
+    "angular-ui-router": "~1.0.6",
   },
   "devDependencies": {
     "gulp": "^3.9.0",


### PR DESCRIPTION
AngularJS ui-router 1.0+ uses $transition events instead of the old $stateChangeSuccess, etc.

Modified the code to use these events / objects instead. Haven't completely tested all of gsapify-ui-router functionality, but have managed to fix some glaring bugs presented by the change in ui-router.

My main reason for doing this, was `leave:` blocks on the states in ui-router 1.0+ would not be used. Therefore, I could not properly animate a leaving view. Because of this, my exiting view on every transition would just simply disappear, resulting in a blank page with the new view coming in.

This patch fixes basic compatibility for ui-router 1.0+, properly using the animations provided by the `leave:` blocks for states, allowing for animation of exiting views again, as originally intended.