### PR TITLE
Fix type handling for array transition in/out

### DIFF
--- a/angular-gsapify-router.js
+++ b/angular-gsapify-router.js
@@ -118,9 +118,7 @@
               if (dataOpts) {
                 if (angular.isArray(dataOpts) || angular.isFunction(dataOpts)) {
                   opts = $injector.invoke(dataOpts);
-                }
-
-                if (angular.isObject(dataOpts)) {
+                } else if (angular.isObject(dataOpts)) {
                   opts = angular.extend(opts, dataOpts);
                   Object.keys(opts).forEach(function (key) {
                     if (
@@ -130,9 +128,7 @@
                       opts[key] = $injector.invoke(opts[key]);
                     }
                   });
-                }
-
-                if (angular.isString(dataOpts)) {
+                } else if (angular.isString(dataOpts)) {
                   opts.transition = dataOpts;
                 }
               }


### PR DESCRIPTION
As discussed in the issue, when the object passed in is an Array, the old version of the code used to run the injection code and exit based on the type checking logic. This version keeps the enhancement of using the angular type checks but switches the logic to an if/else block to match the original intention of the code before it was changed. 